### PR TITLE
Serve dot files from static directory

### DIFF
--- a/.changeset/twenty-brooms-remain.md
+++ b/.changeset/twenty-brooms-remain.md
@@ -1,0 +1,5 @@
+---
+"astro-node-fastify": minor
+---
+
+Added `dotPrefixes` option to allow serving dot files. (Defaults to `/.well-known`)

--- a/astro-adapter/src/index.ts
+++ b/astro-adapter/src/index.ts
@@ -75,6 +75,7 @@ export default function createIntegration(userOptions?: UserOptions): AstroInteg
                     cache: userOptions?.cache,
                     clientPath: pathRelative(fileURLToPath(config.build.server), fileURLToPath(config.build.client)),
                     defaultHeaders: userOptions?.defaultHeaders,
+                    dotPrefixes: userOptions?.dotPrefixes ?? ['/.well-known/'],
                     host:
                         typeof config.server.host === 'boolean'
                             ? config.server.host

--- a/astro-adapter/src/server.ts
+++ b/astro-adapter/src/server.ts
@@ -74,6 +74,7 @@ export async function createServer(app: NodeApp, options: RuntimeArguments): Pro
         dotfiles: allowDotPrefixes ? 'allow' : 'ignore',
         preCompressed: options.preCompressed,
         root: assetRoot,
+        serveDotFiles: allowDotPrefixes,
         setHeaders: setAssetHeaders(
             pathJoin(assetRoot, options.assetsDir),
             options.defaultHeaders?.assets,

--- a/astro-adapter/src/tests/utils/astro-fixture.ts
+++ b/astro-adapter/src/tests/utils/astro-fixture.ts
@@ -1,14 +1,14 @@
 import { rm } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
-import type { AstroConfig, AstroInlineConfig, PreviewServer } from 'astro'
+import type { AstroConfig, AstroInlineConfig } from 'astro'
 import getPort from 'get-port'
 // these imports need to use a relative path since the package doesn't export the required files
 import build from '../../../../node_modules/astro/dist/core/build/index.js'
 import { mergeConfig, resolveConfig } from '../../../../node_modules/astro/dist/core/config/index.js'
-import { preview } from '../../../../node_modules/astro/dist/core/index.js'
 import createIntegration from '../../index.js'
 import type { SupportedExports } from '../../standalone.js'
-import type { UserOptions } from '../../typings/config.js'
+import type { RuntimeArguments, UserOptions } from '../../typings/config.js'
+import type { FastifyInstance } from 'fastify'
 
 // Disable telemetry
 process.env.ASTRO_TELEMETRY_DISABLED = '1'
@@ -23,10 +23,15 @@ export interface TestFixture {
     config: AstroConfig
 
     fetch(url: URL | string, init?: RequestInit): Promise<Response>
+
     loadEntryPoint(): Promise<SupportedExports>
-    preview(overrideConfig?: Partial<AstroFixtureOptions>): Promise<PreviewServer>
+
+    preview(overrideConfig?: Partial<RuntimeArguments>): Promise<FastifyInstance>
+
     resolveClientPath(relativePath: URL | string): URL
+
     resolveUrl(relativeUrl: URL | string): URL
+
     teardown(): Promise<void>
 }
 
@@ -85,7 +90,7 @@ export async function loadFixture(fixtureConfig: AstroFixtureOptions): Promise<T
     }
 
     const resolveUrl = resolveConfigUrl(astroConfig)
-    let serverRef: PreviewServer | undefined
+    let serverRef: FastifyInstance | undefined
 
     return {
         config: astroConfig,
@@ -111,16 +116,30 @@ export async function loadFixture(fixtureConfig: AstroFixtureOptions): Promise<T
         resolveClientPath(relativePath: URL | string): URL {
             return new URL(relativePath, astroConfig.build.client)
         },
-        async preview(overrideConfig: Partial<AstroFixtureOptions> = {}): Promise<PreviewServer> {
+        async preview(overrideConfig: Partial<RuntimeArguments> = {}): Promise<FastifyInstance> {
             process.env.NODE_ENV = 'production'
+            process.env.ASTRO_NODE_FASTIFY_INTERNAL_AUTOSTART = '0'
 
-            const previewServer = await preview(mergeConfig(fixtureConfig, overrideConfig))
+            const entrypointUrl = new URL(`./entry.mjs?ts=${Date.now()}`, astroConfig.build.server)
+            const { startServer } = (await import(entrypointUrl.href)) as SupportedExports
 
-            astroConfig.server.host = previewServer.host || 'localhost'
-            astroConfig.server.port = previewServer.port
-            serverRef = previewServer
+            serverRef = await startServer({
+                ...overrideConfig,
+                serverPath: fileURLToPath(astroConfig.build.server)
+            })
 
-            return previewServer
+            const addresses = serverRef.addresses()
+
+            if (addresses.length === 0) {
+                throw new Error('Server was unable to bind to any address')
+            }
+
+            // biome-ignore lint/style/noNonNullAssertion: array contains at least one element
+            astroConfig.server.host = addresses[0]!.address
+            // biome-ignore lint/style/noNonNullAssertion: array contains at least one element
+            astroConfig.server.port = addresses[0]!.port
+
+            return serverRef
         },
         async loadEntryPoint(): Promise<SupportedExports> {
             process.env.ASTRO_NODE_FASTIFY_INTERNAL_AUTOSTART = '0'
@@ -130,8 +149,7 @@ export async function loadFixture(fixtureConfig: AstroFixtureOptions): Promise<T
         async teardown(): Promise<void> {
             try {
                 if (serverRef) {
-                    await serverRef.stop()
-                    await serverRef.closed()
+                    await serverRef.close()
                 }
             } finally {
                 await rm(astroConfig.outDir, {

--- a/astro-adapter/src/tests/utils/astro-fixture.ts
+++ b/astro-adapter/src/tests/utils/astro-fixture.ts
@@ -1,6 +1,7 @@
 import { rm } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import type { AstroConfig, AstroInlineConfig } from 'astro'
+import type { FastifyInstance } from 'fastify'
 import getPort from 'get-port'
 // these imports need to use a relative path since the package doesn't export the required files
 import build from '../../../../node_modules/astro/dist/core/build/index.js'
@@ -8,7 +9,6 @@ import { mergeConfig, resolveConfig } from '../../../../node_modules/astro/dist/
 import createIntegration from '../../index.js'
 import type { SupportedExports } from '../../standalone.js'
 import type { RuntimeArguments, UserOptions } from '../../typings/config.js'
-import type { FastifyInstance } from 'fastify'
 
 // Disable telemetry
 process.env.ASTRO_TELEMETRY_DISABLED = '1'

--- a/astro-adapter/src/typings/config.ts
+++ b/astro-adapter/src/typings/config.ts
@@ -28,6 +28,12 @@ export interface UserOptions {
      */
     defaultHeaders?: PartialUndef<DefaultHeaderOptions> | undefined
     /**
+     * Specifies which "dot files" (directories or files starting with a `.`) can be served.
+     *
+     * @default ['/.well-known/']
+     */
+    dotPrefixes?: string[] | undefined
+    /**
      * Controls whether the static assets should be pre-compressed or if they should be dynamically compressed at runtime.
      *
      * @default true
@@ -52,6 +58,7 @@ export interface UserOptions {
 export interface RuntimeOptions extends EnvironmentConfig {
     cache?: PartialUndef<CacheOptions> | undefined
     defaultHeaders?: PartialUndef<DefaultHeaderOptions> | undefined
+    dotPrefixes?: string[] | undefined
     preCompressed: boolean
     supportedEncodings: EncodingToken[]
 }

--- a/fixtures/astro-ssr-dot-prefix/astro.config.mjs
+++ b/fixtures/astro-ssr-dot-prefix/astro.config.mjs
@@ -1,0 +1,11 @@
+import nodeFastify from 'astro-node-fastify'
+import { defineConfig } from 'astro/config'
+
+export default defineConfig({
+    adapter: nodeFastify({
+        server: {
+            logLevel: 'fatal'
+        }
+    }),
+    output: 'server'
+})

--- a/fixtures/astro-ssr-dot-prefix/package.json
+++ b/fixtures/astro-ssr-dot-prefix/package.json
@@ -1,0 +1,10 @@
+{
+    "dependencies": {
+        "astro-node-fastify": "*",
+        "astro": "*"
+    },
+    "name": "astro-ssr-dot-prefix",
+    "private": true,
+    "type": "module",
+    "version": "0.0.0"
+}

--- a/fixtures/astro-ssr-dot-prefix/public/.well-known/test.txt
+++ b/fixtures/astro-ssr-dot-prefix/public/.well-known/test.txt
@@ -1,0 +1,1 @@
+hello world

--- a/fixtures/astro-ssr-dot-prefix/public/api/.path.txt
+++ b/fixtures/astro-ssr-dot-prefix/public/api/.path.txt
@@ -1,0 +1,1 @@
+dot API path

--- a/fixtures/astro-ssr-dot-prefix/public/api/test.txt
+++ b/fixtures/astro-ssr-dot-prefix/public/api/test.txt
@@ -1,0 +1,1 @@
+hello world

--- a/fixtures/astro-ssr-dot-prefix/src/env.d.ts
+++ b/fixtures/astro-ssr-dot-prefix/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../.astro/types.d.ts" />

--- a/fixtures/astro-ssr-dot-prefix/src/pages/echo.ts
+++ b/fixtures/astro-ssr-dot-prefix/src/pages/echo.ts
@@ -1,0 +1,10 @@
+import type { APIContext } from 'astro'
+
+export async function POST(context: APIContext): Promise<Response> {
+    return new Response(context.request.body, {
+        status: 200,
+        headers: {
+            'content-type': context.request.headers.get('content-type') || 'application/octet-stream'
+        }
+    })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,6 +108,13 @@
                 "astro-node-fastify": "*"
             }
         },
+        "fixtures/astro-ssr-dot-prefix": {
+            "version": "0.0.0",
+            "dependencies": {
+                "astro": "*",
+                "astro-node-fastify": "*"
+            }
+        },
         "fixtures/astro-ssr-headers-base": {
             "version": "0.0.0",
             "dependencies": {
@@ -2084,9 +2091,9 @@
             "license": "MIT"
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.34.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.2.tgz",
-            "integrity": "sha512-6Fyg9yQbwJR+ykVdT9sid1oc2ewejS6h4wzQltmJfSW53N60G/ah9pngXGANdy9/aaE/TcUFpWosdm7JXS1WTQ==",
+            "version": "4.34.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.4.tgz",
+            "integrity": "sha512-gGi5adZWvjtJU7Axs//CWaQbQd/vGy8KGcnEaCWiyCqxWYDxwIlAHFuSe6Guoxtd0SRvSfVTDMPd5H+4KE2kKA==",
             "cpu": [
                 "arm"
             ],
@@ -2097,9 +2104,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.34.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.2.tgz",
-            "integrity": "sha512-K5GfWe+vtQ3kyEbihrimM38UgX57UqHp+oME7X/EX9Im6suwZfa7Hsr8AtzbJvukTpwMGs+4s29YMSO3rwWtsw==",
+            "version": "4.34.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.4.tgz",
+            "integrity": "sha512-1aRlh1gqtF7vNPMnlf1vJKk72Yshw5zknR/ZAVh7zycRAGF2XBMVDAHmFQz/Zws5k++nux3LOq/Ejj1WrDR6xg==",
             "cpu": [
                 "arm64"
             ],
@@ -2110,9 +2117,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.34.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.2.tgz",
-            "integrity": "sha512-PSN58XG/V/tzqDb9kDGutUruycgylMlUE59f40ny6QIRNsTEIZsrNQTJKUN2keMMSmlzgunMFqyaGLmly39sug==",
+            "version": "4.34.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.4.tgz",
+            "integrity": "sha512-drHl+4qhFj+PV/jrQ78p9ch6A0MfNVZScl/nBps5a7u01aGf/GuBRrHnRegA9bP222CBDfjYbFdjkIJ/FurvSQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2123,9 +2130,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.34.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.2.tgz",
-            "integrity": "sha512-gQhK788rQJm9pzmXyfBB84VHViDERhAhzGafw+E5mUpnGKuxZGkMVDa3wgDFKT6ukLC5V7QTifzsUKdNVxp5qQ==",
+            "version": "4.34.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.4.tgz",
+            "integrity": "sha512-hQqq/8QALU6t1+fbNmm6dwYsa0PDD4L5r3TpHx9dNl+aSEMnIksHZkSO3AVH+hBMvZhpumIGrTFj8XCOGuIXjw==",
             "cpu": [
                 "x64"
             ],
@@ -2136,9 +2143,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.34.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.2.tgz",
-            "integrity": "sha512-eiaHgQwGPpxLC3+zTAcdKl4VsBl3r0AiJOd1Um/ArEzAjN/dbPK1nROHrVkdnoE6p7Svvn04w3f/jEZSTVHunA==",
+            "version": "4.34.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.4.tgz",
+            "integrity": "sha512-/L0LixBmbefkec1JTeAQJP0ETzGjFtNml2gpQXA8rpLo7Md+iXQzo9kwEgzyat5Q+OG/C//2B9Fx52UxsOXbzw==",
             "cpu": [
                 "arm64"
             ],
@@ -2149,9 +2156,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.34.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.2.tgz",
-            "integrity": "sha512-lhdiwQ+jf8pewYOTG4bag0Qd68Jn1v2gO1i0mTuiD+Qkt5vNfHVK/jrT7uVvycV8ZchlzXp5HDVmhpzjC6mh0g==",
+            "version": "4.34.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.4.tgz",
+            "integrity": "sha512-6Rk3PLRK+b8L/M6m/x6Mfj60LhAUcLJ34oPaxufA+CfqkUrDoUPQYFdRrhqyOvtOKXLJZJwxlOLbQjNYQcRQfw==",
             "cpu": [
                 "x64"
             ],
@@ -2162,9 +2169,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.34.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.2.tgz",
-            "integrity": "sha512-lfqTpWjSvbgQP1vqGTXdv+/kxIznKXZlI109WkIFPbud41bjigjNmOAAKoazmRGx+k9e3rtIdbq2pQZPV1pMig==",
+            "version": "4.34.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.4.tgz",
+            "integrity": "sha512-kmT3x0IPRuXY/tNoABp2nDvI9EvdiS2JZsd4I9yOcLCCViKsP0gB38mVHOhluzx+SSVnM1KNn9k6osyXZhLoCA==",
             "cpu": [
                 "arm"
             ],
@@ -2175,9 +2182,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.34.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.2.tgz",
-            "integrity": "sha512-RGjqULqIurqqv+NJTyuPgdZhka8ImMLB32YwUle2BPTDqDoXNgwFjdjQC59FbSk08z0IqlRJjrJ0AvDQ5W5lpw==",
+            "version": "4.34.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.4.tgz",
+            "integrity": "sha512-3iSA9tx+4PZcJH/Wnwsvx/BY4qHpit/u2YoZoXugWVfc36/4mRkgGEoRbRV7nzNBSCOgbWMeuQ27IQWgJ7tRzw==",
             "cpu": [
                 "arm"
             ],
@@ -2188,9 +2195,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.34.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.2.tgz",
-            "integrity": "sha512-ZvkPiheyXtXlFqHpsdgscx+tZ7hoR59vOettvArinEspq5fxSDSgfF+L5wqqJ9R4t+n53nyn0sKxeXlik7AY9Q==",
+            "version": "4.34.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.4.tgz",
+            "integrity": "sha512-7CwSJW+sEhM9sESEk+pEREF2JL0BmyCro8UyTq0Kyh0nu1v0QPNY3yfLPFKChzVoUmaKj8zbdgBxUhBRR+xGxg==",
             "cpu": [
                 "arm64"
             ],
@@ -2201,9 +2208,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.34.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.2.tgz",
-            "integrity": "sha512-UlFk+E46TZEoxD9ufLKDBzfSG7Ki03fo6hsNRRRHF+KuvNZ5vd1RRVQm8YZlGsjcJG8R252XFK0xNPay+4WV7w==",
+            "version": "4.34.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.4.tgz",
+            "integrity": "sha512-GZdafB41/4s12j8Ss2izofjeFXRAAM7sHCb+S4JsI9vaONX/zQ8cXd87B9MRU/igGAJkKvmFmJJBeeT9jJ5Cbw==",
             "cpu": [
                 "arm64"
             ],
@@ -2214,9 +2221,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-            "version": "4.34.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.2.tgz",
-            "integrity": "sha512-hJhfsD9ykx59jZuuoQgYT1GEcNNi3RCoEmbo5OGfG8RlHOiVS7iVNev9rhLKh7UBYq409f4uEw0cclTXx8nh8Q==",
+            "version": "4.34.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.4.tgz",
+            "integrity": "sha512-uuphLuw1X6ur11675c2twC6YxbzyLSpWggvdawTUamlsoUv81aAXRMPBC1uvQllnBGls0Qt5Siw8reSIBnbdqQ==",
             "cpu": [
                 "loong64"
             ],
@@ -2227,9 +2234,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.34.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.2.tgz",
-            "integrity": "sha512-g/O5IpgtrQqPegvqopvmdCF9vneLE7eqYfdPWW8yjPS8f63DNam3U4ARL1PNNB64XHZDHKpvO2Giftf43puB8Q==",
+            "version": "4.34.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.4.tgz",
+            "integrity": "sha512-KvLEw1os2gSmD6k6QPCQMm2T9P2GYvsMZMRpMz78QpSoEevHbV/KOUbI/46/JRalhtSAYZBYLAnT9YE4i/l4vg==",
             "cpu": [
                 "ppc64"
             ],
@@ -2240,9 +2247,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.34.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.2.tgz",
-            "integrity": "sha512-bSQijDC96M6PuooOuXHpvXUYiIwsnDmqGU8+br2U7iPoykNi9JtMUpN7K6xml29e0evK0/g0D1qbAUzWZFHY5Q==",
+            "version": "4.34.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.4.tgz",
+            "integrity": "sha512-wcpCLHGM9yv+3Dql/CI4zrY2mpQ4WFergD3c9cpRowltEh5I84pRT/EuHZsG0In4eBPPYthXnuR++HrFkeqwkA==",
             "cpu": [
                 "riscv64"
             ],
@@ -2253,9 +2260,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.34.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.2.tgz",
-            "integrity": "sha512-49TtdeVAsdRuiUHXPrFVucaP4SivazetGUVH8CIxVsNsaPHV4PFkpLmH9LeqU/R4Nbgky9lzX5Xe1NrzLyraVA==",
+            "version": "4.34.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.4.tgz",
+            "integrity": "sha512-nLbfQp2lbJYU8obhRQusXKbuiqm4jSJteLwfjnunDT5ugBKdxqw1X9KWwk8xp1OMC6P5d0WbzxzhWoznuVK6XA==",
             "cpu": [
                 "s390x"
             ],
@@ -2266,9 +2273,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.34.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.2.tgz",
-            "integrity": "sha512-j+jFdfOycLIQ7FWKka9Zd3qvsIyugg5LeZuHF6kFlXo6MSOc6R1w37YUVy8VpAKd81LMWGi5g9J25P09M0SSIw==",
+            "version": "4.34.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.4.tgz",
+            "integrity": "sha512-JGejzEfVzqc/XNiCKZj14eb6s5w8DdWlnQ5tWUbs99kkdvfq9btxxVX97AaxiUX7xJTKFA0LwoS0KU8C2faZRg==",
             "cpu": [
                 "x64"
             ],
@@ -2279,9 +2286,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.34.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.2.tgz",
-            "integrity": "sha512-aDPHyM/D2SpXfSNCVWCxyHmOqN9qb7SWkY1+vaXqMNMXslZYnwh9V/UCudl6psyG0v6Ukj7pXanIpfZwCOEMUg==",
+            "version": "4.34.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.4.tgz",
+            "integrity": "sha512-/iFIbhzeyZZy49ozAWJ1ZR2KW6ZdYUbQXLT4O5n1cRZRoTpwExnHLjlurDXXPKEGxiAg0ujaR9JDYKljpr2fDg==",
             "cpu": [
                 "x64"
             ],
@@ -2292,9 +2299,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.34.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.2.tgz",
-            "integrity": "sha512-LQRkCyUBnAo7r8dbEdtNU08EKLCJMgAk2oP5H3R7BnUlKLqgR3dUjrLBVirmc1RK6U6qhtDw29Dimeer8d5hzQ==",
+            "version": "4.34.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.4.tgz",
+            "integrity": "sha512-qORc3UzoD5UUTneiP2Afg5n5Ti1GAW9Gp5vHPxzvAFFA3FBaum9WqGvYXGf+c7beFdOKNos31/41PRMUwh1tpA==",
             "cpu": [
                 "arm64"
             ],
@@ -2305,9 +2312,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.34.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.2.tgz",
-            "integrity": "sha512-wt8OhpQUi6JuPFkm1wbVi1BByeag87LDFzeKSXzIdGcX4bMLqORTtKxLoCbV57BHYNSUSOKlSL4BYYUghainYA==",
+            "version": "4.34.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.4.tgz",
+            "integrity": "sha512-5g7E2PHNK2uvoD5bASBD9aelm44nf1w4I5FEI7MPHLWcCSrR8JragXZWgKPXk5i2FU3JFfa6CGZLw2RrGBHs2Q==",
             "cpu": [
                 "ia32"
             ],
@@ -2318,9 +2325,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.34.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.2.tgz",
-            "integrity": "sha512-rUrqINax0TvrPBXrFKg0YbQx18NpPN3NNrgmaao9xRNbTwek7lOXObhx8tQy8gelmQ/gLaGy1WptpU2eKJZImg==",
+            "version": "4.34.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.4.tgz",
+            "integrity": "sha512-p0scwGkR4kZ242xLPBuhSckrJ734frz6v9xZzD+kHVYRAkSUmdSLCIJRfql6H5//aF8Q10K+i7q8DiPfZp0b7A==",
             "cpu": [
                 "x64"
             ],
@@ -2823,6 +2830,10 @@
             "resolved": "fixtures/astro-ssr-default-base",
             "link": true
         },
+        "node_modules/astro-ssr-dot-prefix": {
+            "resolved": "fixtures/astro-ssr-dot-prefix",
+            "link": true
+        },
         "node_modules/astro-ssr-headers-base": {
             "resolved": "fixtures/astro-ssr-headers-base",
             "link": true
@@ -2899,14 +2910,14 @@
             "peer": true
         },
         "node_modules/astro/node_modules/vite": {
-            "version": "6.0.11",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz",
-            "integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.1.0.tgz",
+            "integrity": "sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==",
             "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.24.2",
-                "postcss": "^8.4.49",
-                "rollup": "^4.23.0"
+                "postcss": "^8.5.1",
+                "rollup": "^4.30.1"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -4139,9 +4150,9 @@
             }
         },
         "node_modules/find-my-way": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.1.0.tgz",
-            "integrity": "sha512-Y5jIsuYR4BwWDYYQ2A/RWWE6gD8a0FMgtU+HOq1WKku+Cwdz8M1v8wcAmRXXM1/iqtoqg06v+LjAxMYbCjViMw==",
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.2.0.tgz",
+            "integrity": "sha512-d3uCir8Hmg7W1Ywp8nKf2lJJYU9Nwinvo+1D39Dn09nz65UKXIxUh7j7K8zeWhxqe1WrkS7FJyON/Q/3lPoc6w==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -7433,9 +7444,9 @@
             "license": "MIT"
         },
         "node_modules/rollup": {
-            "version": "4.34.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.2.tgz",
-            "integrity": "sha512-sBDUoxZEaqLu9QeNalL8v3jw6WjPku4wfZGyTU7l7m1oC+rpRihXc/n/H+4148ZkGz5Xli8CHMns//fFGKvpIQ==",
+            "version": "4.34.4",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.4.tgz",
+            "integrity": "sha512-spF66xoyD7rz3o08sHP7wogp1gZ6itSq22SGa/IZTcUDXDlOyrShwMwkVSB+BUxFRZZCUYqdb3KWDEOMVQZxuw==",
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "1.0.6"
@@ -7448,25 +7459,25 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.34.2",
-                "@rollup/rollup-android-arm64": "4.34.2",
-                "@rollup/rollup-darwin-arm64": "4.34.2",
-                "@rollup/rollup-darwin-x64": "4.34.2",
-                "@rollup/rollup-freebsd-arm64": "4.34.2",
-                "@rollup/rollup-freebsd-x64": "4.34.2",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.34.2",
-                "@rollup/rollup-linux-arm-musleabihf": "4.34.2",
-                "@rollup/rollup-linux-arm64-gnu": "4.34.2",
-                "@rollup/rollup-linux-arm64-musl": "4.34.2",
-                "@rollup/rollup-linux-loongarch64-gnu": "4.34.2",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.34.2",
-                "@rollup/rollup-linux-riscv64-gnu": "4.34.2",
-                "@rollup/rollup-linux-s390x-gnu": "4.34.2",
-                "@rollup/rollup-linux-x64-gnu": "4.34.2",
-                "@rollup/rollup-linux-x64-musl": "4.34.2",
-                "@rollup/rollup-win32-arm64-msvc": "4.34.2",
-                "@rollup/rollup-win32-ia32-msvc": "4.34.2",
-                "@rollup/rollup-win32-x64-msvc": "4.34.2",
+                "@rollup/rollup-android-arm-eabi": "4.34.4",
+                "@rollup/rollup-android-arm64": "4.34.4",
+                "@rollup/rollup-darwin-arm64": "4.34.4",
+                "@rollup/rollup-darwin-x64": "4.34.4",
+                "@rollup/rollup-freebsd-arm64": "4.34.4",
+                "@rollup/rollup-freebsd-x64": "4.34.4",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.34.4",
+                "@rollup/rollup-linux-arm-musleabihf": "4.34.4",
+                "@rollup/rollup-linux-arm64-gnu": "4.34.4",
+                "@rollup/rollup-linux-arm64-musl": "4.34.4",
+                "@rollup/rollup-linux-loongarch64-gnu": "4.34.4",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.34.4",
+                "@rollup/rollup-linux-riscv64-gnu": "4.34.4",
+                "@rollup/rollup-linux-s390x-gnu": "4.34.4",
+                "@rollup/rollup-linux-x64-gnu": "4.34.4",
+                "@rollup/rollup-linux-x64-musl": "4.34.4",
+                "@rollup/rollup-win32-arm64-msvc": "4.34.4",
+                "@rollup/rollup-win32-ia32-msvc": "4.34.4",
+                "@rollup/rollup-win32-x64-msvc": "4.34.4",
                 "fsevents": "~2.3.2"
             }
         },


### PR DESCRIPTION
Adds a `dotPrefixes` option which allows configuring a list of prefixes that can be served from the "public" directory.

Resolves #168.