### PR TITLE
Update static cache control max-age

### DIFF
--- a/astro-adapter/src/server.ts
+++ b/astro-adapter/src/server.ts
@@ -149,7 +149,7 @@ function setAssetHeaders(
 
     return (res: SetHeadersResponse, path: string): void => {
         if (path.startsWith(staticPrefix)) {
-            res.setHeader('Cache-Control', 'public, max-age=604800, immutable')
+            res.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
         } else if (dynamicAssetCacheControl !== undefined) {
             res.setHeader('Cache-Control', dynamicAssetCacheControl)
         }


### PR DESCRIPTION
Update static cache-control max-age to 31536000 as recommended by https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#immutable